### PR TITLE
Finalize migration from gemalto/requester to ThalesGroup/requester

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Requester
-[![GoDoc](https://godoc.org/github.com/gemalto/requester?status.png)](https://godoc.org/github.com/gemalto/requester) [![Go Report Card](https://goreportcard.com/badge/github.com/gemalto/requester)](https://goreportcard.com/report/github.com/gemalto/requester) [![Build](https://github.com/gemalto/requester/workflows/Build/badge.svg)](https://github.com/gemalto/requester/actions?query=branch%3Amaster+workflow%3ABuild+)
+[![GoDoc](https://godoc.org/github.com/ThalesGroup/requester?status.png)](https://godoc.org/github.com/ThalesGroup/requester) [![Go Report Card](https://goreportcard.com/badge/github.com/ThalesGroup/requester)](https://goreportcard.com/report/github.com/ThalesGroup/requester) [![Build](https://github.com/ThalesGroup/requester/workflows/Build/badge.svg)](https://github.com/ThalesGroup/requester/actions?query=branch%3Amaster+workflow%3ABuild+)
 
 A.K.A "Yet Another Golang Requests Package"
 

--- a/doc.go
+++ b/doc.go
@@ -127,14 +127,14 @@ HTTP Client Options
 
 The HTTP client used to execute requests can also be customized with Options:
 
-	import "github.com/gemalto/requester/httpclient"
+	import "github.com/ThalesGroup/requester/httpclient"
 
 	requester.Send(
 		requester.Get("https://api.com"),
 		requester.Client(httpclient.SkipVerify()),
 	)
 
-"github.com/gemalto/requester/httpclient" is a standalone package for constructing and configuring
+"github.com/ThalesGroup/requester/httpclient" is a standalone package for constructing and configuring
 http.Clients.  The requester.Client(...httpclient.Option) option constructs a new HTTP client
 and installs it into Requester.Doer.
 

--- a/example_test.go
+++ b/example_test.go
@@ -2,9 +2,9 @@ package requester_test
 
 import (
 	"fmt"
-	. "github.com/gemalto/requester"
-	"github.com/gemalto/requester/httpclient"
-	"github.com/gemalto/requester/httptestutil"
+	. "github.com/ThalesGroup/requester"
+	"github.com/ThalesGroup/requester/httpclient"
+	"github.com/ThalesGroup/requester/httptestutil"
 	"net/http"
 	"net/http/httptest"
 	"os"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gemalto/requester
+module github.com/ThalesGroup/requester
 
 go 1.14
 

--- a/httptestutil/dump_test.go
+++ b/httptestutil/dump_test.go
@@ -2,7 +2,7 @@ package httptestutil
 
 import (
 	"bytes"
-	"github.com/gemalto/requester"
+	"github.com/ThalesGroup/requester"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"net/http/httptest"

--- a/httptestutil/examples_test.go
+++ b/httptestutil/examples_test.go
@@ -2,8 +2,8 @@ package httptestutil_test
 
 import (
 	"fmt"
-	"github.com/gemalto/requester"
-	"github.com/gemalto/requester/httptestutil"
+	"github.com/ThalesGroup/requester"
+	"github.com/ThalesGroup/requester/httptestutil"
 	"net/http"
 	"net/http/httptest"
 	"strconv"

--- a/httptestutil/inspector_test.go
+++ b/httptestutil/inspector_test.go
@@ -2,7 +2,7 @@ package httptestutil
 
 import (
 	"fmt"
-	"github.com/gemalto/requester"
+	"github.com/ThalesGroup/requester"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io"

--- a/httptestutil/utils.go
+++ b/httptestutil/utils.go
@@ -5,7 +5,7 @@
 package httptestutil
 
 import (
-	"github.com/gemalto/requester"
+	"github.com/ThalesGroup/requester"
 	"net/http/httptest"
 )
 

--- a/options.go
+++ b/options.go
@@ -8,7 +8,7 @@ import (
 	"unicode"
 
 	"github.com/ansel1/merry"
-	"github.com/gemalto/requester/httpclient"
+	"github.com/ThalesGroup/requester/httpclient"
 	goquery "github.com/google/go-querystring/query"
 )
 

--- a/options_test.go
+++ b/options_test.go
@@ -3,7 +3,7 @@ package requester
 import (
 	"context"
 	"fmt"
-	"github.com/gemalto/requester/httpclient"
+	"github.com/ThalesGroup/requester/httpclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"


### PR DESCRIPTION
Hi, 
i use requester for a while and it seems it has move from gemalto to ThalesGroup.
But the import rename not seems to be done for the moment and when i get requester i get a gemalto/request indirect dependency reference

```
mkdir project | cd project
go mod init && go get github.com/ThalesGroup/requester
```

and the go.mod was 

```
module github.com/instabledesign/project

go 1.13

require (
	github.com/ThalesGroup/requester v1.0.2 // indirect
	github.com/ansel1/merry v1.5.1 // indirect
	github.com/gemalto/requester v1.0.2 // indirect
	github.com/google/go-querystring v1.0.0 // indirect
)
```

but i expect 
```
module github.com/instabledesign/project

go 1.13

require (
	github.com/ThalesGroup/requester v1.0.2 // indirect
	github.com/ansel1/merry v1.5.1 // indirect
	github.com/google/go-querystring v1.0.0 // indirect
)
```

Thank's and have a nice day :)